### PR TITLE
fix cowbuilder/pbuilder failures on Debian's AMI because of sources.list ordering

### DIFF
--- a/tasks/21-apt-sources
+++ b/tasks/21-apt-sources
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Basic sources.list
 cat > $imagedir/etc/apt/sources.list <<EOF
-deb http://security.debian.org/       $codename/updates main
-deb-src http://security.debian.org/   $codename/updates main
-deb $apt_mirror     $codename         main
+deb     $apt_mirror $codename         main
 deb-src $apt_mirror $codename         main
+deb     http://security.debian.org/   $codename/updates main
+deb-src http://security.debian.org/   $codename/updates main
 EOF


### PR DESCRIPTION
Creating a cowbuilder/pbuilder environment fails on systems running
the official Debian AMI. Demonstration:

| # cowbuilder --create --distribution squeeze --debootstrapopts --arch --debootstrapopts amd64 --debootstrapopts --variant=buildd
|  -> Invoking pbuilder
|   forking: pbuilder create --debootstrapopts --arch --debootstrapopts amd64 --debootstrapopts --variant=buildd --buildplace /var/cache/pbuilder/base.cow --mirror http://security.debian.org/ --distribution squeeze --no-targz --extrapackages cowdancer
| [...]
| I: Retrieving Release
| E: Failed getting release file http://security.debian.org/dists/squeeze/Release
| E: debootstrap failed
| W: Aborting with an error
| pbuilder create failed
| [...]

This is caused by pbuilder's magic inside pbuilder's postinst
which sets up a /etc/pbuilderrc using MIRRORSITE. MIRRORSITE
itself is calculated by the content of /etc/apt/sources.list.
Demonstration by using pbuilder's postinst code:

| # MIRRORSITE=$(
|   ( [ -f /etc/apt/sources.list ] && cat /etc/apt/sources.list || true ;
|     [ -f $SRCLISTDIR/_.sources.list ] && cat $SRCLISTDIR/_.sources.list || true ) \
|   | grep -E '^deb[[:space:]]+(ftp|http):' | head -n 1 | awk '{print $2;}'
|   )
| # echo $MIRRORSITE
| http://security.debian.org/
| # grep -v '^#' /etc/pbuilderrc
| MIRRORSITE=http://security.debian.org/

By switching the order of the mirrors in /etc/apt/sources.list
this pbuilder/cowbuilder issue with MIRRORSITE can be avoided.
