### PR TITLE
Install ca-certificates package

### DIFF
--- a/tasks/01-packages
+++ b/tasks/01-packages
@@ -8,6 +8,8 @@ packages+=('openssh-server')
 packages+=('locales')
 # Needed for the init scripts
 packages+=('file')
+# Enable e.g. wget to verify certificates
+packages+=('ca-certificates')
 # This is inherited from the original script.
 # Apparently isc-dhcp-client doesn't work properly with ec2
 packages+=('dhcpcd')


### PR DESCRIPTION
Earlier (as in AMIs for v6.0.6) we installed curl, which also pulled in ca-certificates.

Now we install only wget which does not even transitionally depend on it. But without CA certificates, we can not practically download SSL protected content. This is a problem for example when bootstrapping configuration management systems etc.

I can handle this in [knife-solo](http://matschaffer.github.com/knife-solo/) as it detects the OS and distro, but the generic bootstrap template for Chef just downloads an installer script (using https in the future).

IMHO CA certificates should be installed by default as more and more content is behind SSL (which is a good thing!). Other opinions?

/cc @JamesBromberger as I understood you built the latest AMIs.
