### PR TITLE
Add link to ec2debian-chef plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -28,5 +28,8 @@ The following is a list of external plugins you can use with ec2debian-build-ami
 * [ec2-minecraft](https://github.com/andsens/ec2-minecraft)  
   Installs [Minecraft Server Manager](http://marcuswhybrow.net/minecraft-server-manager/) by Marcus Whybrow.
 
+* [ec2debian-chef](https://github.com/tmatilai/ec2debian-chef)  
+  Installs [Opscode Chef](http://www.opscode.com/chef/) client using the Omnibus installer.
+
 That's it for now. If you have made a plugin for ec2debian-build-ami and would like to share it,
 send me a pull request or drop me an email.


### PR DESCRIPTION
Hi Anders,

Would you like to include a link to a [plugin](https://github.com/tmatilai/ec2debian-chef) that I created for installing Chef client? Quite handy now that Vagrant supports EC2. =)
