### PR TITLE
Update references to renamed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 #### Major changes: ####
 * Add `change-root-uuid` script
-  (see [this issue for more info](https://github.com/andsens/ec2debian-build-ami/issues/40))
+  (see [this issue for more info](https://github.com/andsens/build-debian-cloud/issues/40))
 * Remove contrib and non-free from apt/sources.list  
 (thanks to zack for finding this and James for the patch)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Debian community and Amazon have together created AMIs using this bootstrapp
 and replicated them across AWS regions. The images have been tested for security and bugs.
 They are available on the [aws marketplace](https://aws.amazon.com/marketplace/pp/ref=csl_clsc_prd?sku=8fvdn95s5ev33cprr62nq3q7t).
 
-For each new official AMI a commit in this repository will be [tagged](https://github.com/andsens/ec2debian-build-ami/tags),
+For each new official AMI a commit in this repository will be [tagged](https://github.com/andsens/build-debian-cloud/tags),
 marking the version the AMI was bootstrapped with.
 
 More information about these images and links to the gzipped volume images can be found on the
@@ -32,9 +32,9 @@ When creating an AMI the script at least needs to know your AWS credentials.
 There are no interactive prompts, the bootstrapping can run entirely unattended
 from start till finish.
 
-Some plugins are included in the [plugins directory](https://github.com/andsens/ec2debian-build-ami/tree/master/plugins).
+Some plugins are included in the [plugins directory](https://github.com/andsens/build-debian-cloud/tree/master/plugins).
 A list of external plugins is also provided there. If none of those scratch
-your itch, you can of course [write your own plugin](https://github.com/andsens/ec2debian-build-ami/blob/master/plugins/HOWTO.md).
+your itch, you can of course [write your own plugin](https://github.com/andsens/build-debian-cloud/blob/master/plugins/HOWTO.md).
 
 ## Features ##
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,7 @@
 In this folder you will find plugins made for the bootstrapper.  
 You can run them via the `--plugin` option when bootstrapping:  
 ```
-./ec2debian-build-ami --plugin plugins/ec2-run-user-data
+./build-debian-cloud ec2 --plugin plugins/admin-user
 ```
 
 * `standard-packages`  
@@ -22,7 +22,7 @@ You can run them via the `--plugin` option when bootstrapping:
   With this plugin you can inspect the results of the bootstrapping process without launching an instance.
 
 ## Other plugins ##
-The following is a list of external plugins you can use with ec2debian-build-ami.
+The following is a list of external plugins you can use with build-debian-cloud.
 
 * [ec2-autohostname](https://github.com/secoya/ec2-autohostname)  
   Create a Route 53 CNAME record via an instance tag when booting.
@@ -33,5 +33,5 @@ The following is a list of external plugins you can use with ec2debian-build-ami
 * [ec2debian-chef](https://github.com/tmatilai/ec2debian-chef)  
   Installs [Opscode Chef](http://www.opscode.com/chef/) client using the Omnibus installer.
 
-That's it for now. If you have made a plugin for ec2debian-build-ami and would like to share it,
+That's it for now. If you have made a plugin for build-debian-cloud and would like to share it,
 send me a pull request or drop me an email.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,7 +30,7 @@ The following is a list of external plugins you can use with build-debian-cloud.
 * [ec2-minecraft](https://github.com/andsens/ec2-minecraft)  
   Installs [Minecraft Server Manager](http://marcuswhybrow.net/minecraft-server-manager/) by Marcus Whybrow.
 
-* [ec2debian-chef](https://github.com/tmatilai/ec2debian-chef)  
+* [debian-cloud-chef](https://github.com/tmatilai/debian-cloud-chef)  
   Installs [Opscode Chef](http://www.opscode.com/chef/) client using the Omnibus installer.
 
 That's it for now. If you have made a plugin for build-debian-cloud and would like to share it,


### PR DESCRIPTION
Fix links and commands in documentation after renaming the project.

My ec2debian-chef plugin has also been renamed to [debian-cloud-chef](https://github.com/tmatilai/debian-cloud-chef). Update also the link to it.
