### PR TITLE
Instance store ami plugin

### DIFF
--- a/plugins/instance-store-ami
+++ b/plugins/instance-store-ami
@@ -3,6 +3,9 @@ remote_task "05-install-euca2ools"
 insert_task_before "06-patch-boto" "$plugindir/instance-store-ami-tasks/05-install-euca2ools"
 remove_task "06-patch-boto"
 
+# Additional vars for euca tools that manage bundles
+insert_task_after "07-host-information"    "$plugindir/instance-store-ami-tasks/08-more-host-info"
+
 # Remove tasks that create the EBS volume. Instead, we create a loop device
 # for our instance image
 remove_task "10-create-volume"

--- a/plugins/instance-store-ami
+++ b/plugins/instance-store-ami
@@ -23,7 +23,8 @@ insert_task_after "72-unmount-volume"      "$plugindir/instance-store-ami-tasks/
 insert_task_after "73-detach-image-loop"   "$plugindir/instance-store-ami-tasks/80-bundle-image"
 insert_task_after "80-bundle-image"        "$plugindir/instance-store-ami-tasks/81-upload-bundle"
 insert_task_after "81-upload-bundle"       "$plugindir/instance-store-ami-tasks/82-delete-image-file"
+insert_task_after "82-delete-image-file"   "$plugindir/instance-store-ami-tasks/83-delete-bundle-files"
 
 # Replace the AMI registering as the command is different for instance-store AMIs
 remove_task "95-register-ami"
-insert_task_after "82-delete-image-file"   "$plugindir/instance-store-ami-tasks/95-register-ami"
+insert_task_after "83-delete-bundle-files"  "$plugindir/instance-store-ami-tasks/95-register-ami"

--- a/plugins/instance-store-ami
+++ b/plugins/instance-store-ami
@@ -1,4 +1,6 @@
 #!/bin/bash
+remote_task "05-install-euca2ools"
+insert_task_before "06-patch-boto" "$plugindir/instance-store-ami-tasks/05-install-euca2ools"
 remove_task "06-patch-boto"
 
 # Remove tasks that create the EBS volume. Instead, we create a loop device

--- a/plugins/instance-store-ami
+++ b/plugins/instance-store-ami
@@ -1,5 +1,5 @@
 #!/bin/bash
-remote_task "05-install-euca2ools"
+remove_task "05-install-euca2ools"
 insert_task_before "06-patch-boto" "$plugindir/instance-store-ami-tasks/05-install-euca2ools"
 remove_task "06-patch-boto"
 

--- a/plugins/instance-store-ami
+++ b/plugins/instance-store-ami
@@ -1,0 +1,24 @@
+#!/bin/bash
+remove_task "06-patch-boto"
+
+# Remove tasks that create the EBS volume. Instead, we create a loop device
+# for our instance image
+remove_task "10-create-volume"
+remove_task "11-attach-volume"
+insert_task_before "12-format-volume"      "$plugindir/instance-store-ami-tasks/10-create-image-file"
+insert_task_before "12-format-volume"      "$plugindir/instance-store-ami-tasks/11-attach-image-loop"
+
+# Remove tasks that handle the EBS volume and create the snapshot
+remove_task "73-detach-volume"
+remove_task "80-ebs-snapshot"
+remove_task "82-delete-volume"
+
+# New tasks that bundle our image and upload it to S3
+insert_task_after "72-unmount-volume"      "$plugindir/instance-store-ami-tasks/73-detach-image-loop"
+insert_task_after "73-detach-image-loop"   "$plugindir/instance-store-ami-tasks/80-bundle-image"
+insert_task_after "80-bundle-image"        "$plugindir/instance-store-ami-tasks/81-upload-bundle"
+insert_task_after "81-upload-bundle"       "$plugindir/instance-store-ami-tasks/82-delete-image-file"
+
+# Replace the AMI registering as the command is different for instance-store AMIs
+remove_task "95-register-ami"
+insert_task_after "82-delete-image-file"   "$plugindir/instance-store-ami-tasks/95-register-ami"

--- a/plugins/instance-store-ami-tasks/05-install-euca2ools
+++ b/plugins/instance-store-ami-tasks/05-install-euca2ools
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# We use euca2ools to communicate with AWS
+# The package in squeeze is v 1.2, which does not support EBS images
+# So we install 2.1 from source instead
+if [ ! -d $scriptdir/euca2ools ]; then
+	wget -qO $scriptdir/euca2ools-2.1.3.tar.gz https://github.com/eucalyptus/euca2ools/archive/2.1.3.tar.gz
+	tar zxf $scriptdir/euca2ools-2.1.3.tar.gz
+fi
+
+function install_euca2ools {
+	# We want to fail if make fails, so don't start a subshell with ()
+	# Remember the old dir
+	local orig_pwd=$(pwd)
+	cd euca2ools-2.1.3
+        python setup.py build | spin
+	[ $PIPESTATUS == 0 ] || die "euca2ools build failed!"
+        python setup.py install | spin
+	[ $PIPESTATUS == 0 ] || die "euca2ools installation failed!"
+	cd $orig_pwd
+}
+
+# make the euca2ools if they are not installed or the version is wrong
+if ! command -v euca-version > /dev/null 2>&1; then
+	install_euca2ools
+elif [[ ! "`euca-version`" =~ euca2ools\ 2.1.* ]]; then
+	install_euca2ools
+fi

--- a/plugins/instance-store-ami-tasks/08-more-host-info
+++ b/plugins/instance-store-ami-tasks/08-more-host-info
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 export EC2_REGION=${region}
-export S3_URL=https://s3-${region}.amazonaws.com/
+case "${region}" in
+us-east-1)
+  export S3_URL=https://s3.amazonaws.com/
+  ;;
+*)
+  export S3_URL=https://s3-${region}.amazonaws.com/
+  ;;
+esac
 
 test ! -z "$EC2_PRIVATE_KEY" || die "Variable \$EC2_PRIVATE_KEY must be set!"
 test ! -z "$EC2_CERT" || die "Variable \$EC2_CERT must be set!"

--- a/plugins/instance-store-ami-tasks/08-more-host-info
+++ b/plugins/instance-store-ami-tasks/08-more-host-info
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export EC2_REGION=${region}
+export S3_URL=https://s3-${region}.amazonaws.com/
+
+test ! -z "$EC2_PRIVATE_KEY" || die "Variable \$EC2_PRIVATE_KEY must be set!"
+test ! -z "$EC2_CERT" || die "Variable \$EC2_CERT must be set!"
+test ! -z "$EC2_USER_ID" || die "Variable \$EC2_USER_ID must be set!"
+test ! -z "$EUCALYPTUS_CERT" || die "Variable \$EUCALYPTUS_CERT must be set!"
+test ! -z "$S3_BUCKET" || die "Variable \$S3_BUCKET must be set!"
+
+test -f $EC2_PRIVATE_KEY || die "Could not find EC2 private key file - $EC2_PRIVATE_KEY"
+test -f $EC2_CERT || die "Could not find EC2 private key file - $EC2_CERT"
+test -f $EUCALYPTUS_CERT || die "Could not find EC2 private key file - $EUCALYPTUS_CERT"

--- a/plugins/instance-store-ami-tasks/10-create-image-file
+++ b/plugins/instance-store-ami-tasks/10-create-image-file
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Create a file for our instance image 
+
+volume_id=instance-$RANDOM
+imagefile=$debootstrap_dir/${volume_id}.img
+
+if [ -f "$imagefile" ]; then
+  die "The image file $imagefile already exists."
+fi
+
+# Create a sparse file of $volume_site GB
+dd if=/dev/zero of=$imagefile bs=1 seek=${volume_size}G count=0
+if [ $? -ne 0 ]; then
+  die "Unable to create image file '${imagefile}'."
+fi
+log "Successfully created image file."

--- a/plugins/instance-store-ami-tasks/11-attach-image-loop
+++ b/plugins/instance-store-ami-tasks/11-attach-image-loop
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Create a loop device and attach our instance image file
+
+device_path=`losetup --find`
+
+losetup $device_path $imagefile
+if [ $? -ne 0 ]; then
+  die "Unable to attach image file to loop device '${device_path}'."
+fi
+log "Successfully created instance image loop device '${device_path}'." 

--- a/plugins/instance-store-ami-tasks/73-detach-image-loop
+++ b/plugins/instance-store-ami-tasks/73-detach-image-loop
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Detach instance image loop device
+log "Detaching image loop device."
+losetup -d $device_path

--- a/plugins/instance-store-ami-tasks/80-bundle-image
+++ b/plugins/instance-store-ami-tasks/80-bundle-image
@@ -4,8 +4,9 @@
 bundledir=${debootstrap_dir}/${volume_id}-bundle
 mkdir $bundledir
 
-euca-bundle-image -i $imagefile -d $bundledir -p "${volume_id}"
+ami_name="$distribution-$codename-$arch-$name_suffix"
+
+euca-bundle-image -i $imagefile -d $bundledir -p "${ami_name}"
 if [ $? -ne 0 ]; then
   die "Unable to bundle instance image."
 fi
-log "Successully created an instance image bundle."

--- a/plugins/instance-store-ami-tasks/80-bundle-image
+++ b/plugins/instance-store-ami-tasks/80-bundle-image
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Bundle of instance image
+
+bundledir=${debootstrap_dir}/${volume_id}-bundle
+mkdir $bundledir
+
+euca-bundle-image -i $imagefile -d $bundledir -p "${volume_id}"
+if [ $? -ne 0 ]; then
+  die "Unable to bundle instance image."
+fi
+log "Successully created an instance image bundle."

--- a/plugins/instance-store-ami-tasks/81-upload-bundle
+++ b/plugins/instance-store-ami-tasks/81-upload-bundle
@@ -1,11 +1,7 @@
 #!/bin/bash
 # Upload instance image bundle to S3
 
-bucketname="debian-ami-test2"
-
-log "euca-upload-bundle -b \"${bucketname}\" -m \"${bundledir}/${volume_id}.manifest.xml\" --location \"${region}\""
-euca-upload-bundle -b "${bucketname}" -m "${bundledir}/${volume_id}.manifest.xml" --location "${region}"
+euca-upload-bundle -b "${S3_BUCKET}" -m "${bundledir}/${ami_name}.manifest.xml"
 if [ $? -ne 0 ]; then
   die "Unable to upload image bundle to S3."
 fi
-log "Successully uploaded image bundle to S3."

--- a/plugins/instance-store-ami-tasks/81-upload-bundle
+++ b/plugins/instance-store-ami-tasks/81-upload-bundle
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Upload instance image bundle to S3
+
+bucketname="debian-ami-test2"
+
+log "euca-upload-bundle -b \"${bucketname}\" -m \"${bundledir}/${volume_id}.manifest.xml\" --location \"${region}\""
+euca-upload-bundle -b "${bucketname}" -m "${bundledir}/${volume_id}.manifest.xml" --location "${region}"
+if [ $? -ne 0 ]; then
+  die "Unable to upload image bundle to S3."
+fi
+log "Successully uploaded image bundle to S3."

--- a/plugins/instance-store-ami-tasks/82-delete-image-file
+++ b/plugins/instance-store-ami-tasks/82-delete-image-file
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Delete instance image file
+log "Deleting the image file"
+rm $imagefile

--- a/plugins/instance-store-ami-tasks/83-delete-bundle-files
+++ b/plugins/instance-store-ami-tasks/83-delete-bundle-files
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Delete instance bundled files
+rm -fr $bundledir

--- a/plugins/instance-store-ami-tasks/95-register-ami
+++ b/plugins/instance-store-ami-tasks/95-register-ami
@@ -48,7 +48,8 @@ esac
 
 ami_name="$distribution-$codename-$arch-$name_suffix"
 log "Registering an AMI"
-ami_id=`euca-register "${bucketname}/${volume_id}.manifest.xml" \
+ami_id=`euca-register \
+        "${S3_BUCKET}/${ami_name}.manifest.xml" \
         --name "$ami_name" --description "$description" \
         --architecture "$ami_arch" --kernel "$aki" \
         | awk '{print $2}'`
@@ -56,14 +57,13 @@ ami_id=`euca-register "${bucketname}/${volume_id}.manifest.xml" \
 # If the user has already created an unnamed AMI today,
 # this will fail, so give the AMI registration command to the user
 if [[ ! "$ami_id" =~ ^ami-[0-9a-z]{8}$ ]]; then
-	die "Unable to register an AMI."
-#        die \
-#                "Unable to register an AMI." \
-#                "You can do it manually with:" \
-#                "`which euca-register` \\\\" \
-#                "--name '$ami_name' --description '$description' \\\\" \
-#                "--architecture '$ami_arch' --kernel '$aki' \\\\" \
-#                "--snapshot '$snapshot_id:$volume_size:true:standard'"
+        die \
+                "Unable to register an AMI." \
+                "You can do it manually with:" \
+                "`which euca-register` \\\\" \
+                "'${S3_BUCKET}/${ami_name}.manifest.xml' \\\\" \
+                "--name '$ami_name' --description '$description' \\\\" \
+                "--architecture '$ami_arch' --kernel '$aki'"
 fi
 log "Your AMI has been created with the ID '$ami_id'"
 

--- a/plugins/instance-store-ami-tasks/95-register-ami
+++ b/plugins/instance-store-ami-tasks/95-register-ami
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Register the uploaded bundle as a new AMI
+
+# Figure out which pvGrub kernel ID we need
+case $region in
+        us-east-1)
+                [ $arch = 'amd64' ] && aki="aki-88aa75e1"
+                [ $arch = 'i386' ] && aki="aki-b6aa75df"
+        ;;
+        us-west-1)
+                [ $arch = 'amd64' ] && aki="aki-f77e26b2"
+                [ $arch = 'i386' ] && aki="aki-f57e26b0"
+        ;;
+        us-west-2)
+                [ $arch = 'amd64' ] && aki="aki-fc37bacc"
+                [ $arch = 'i386' ] && aki="aki-fa37baca"
+        ;;
+        eu-west-1)
+                [ $arch = 'amd64' ] && aki="aki-71665e05"
+                [ $arch = 'i386' ] && aki="aki-75665e01"
+        ;;
+        ap-southeast-1)
+                [ $arch = 'amd64' ] && aki="aki-fe1354ac"
+                [ $arch = 'i386' ] && aki="aki-f81354aa"
+        ;;
+        ap-southeast-2)
+                [ $arch = 'amd64' ] && aki="aki-31990e0b"
+                [ $arch = 'i386' ] && aki="aki-33990e09"
+        ;;
+        ap-northeast-1)
+                [ $arch = 'amd64' ] && aki="aki-44992845"
+                [ $arch = 'i386' ] && aki="aki-42992843"
+        ;;
+        sa-east-1)
+                [ $arch = 'amd64' ] && aki="aki-c48f51d9"
+                [ $arch = 'i386' ] && aki="aki-ca8f51d7"
+        ;;
+        us-gov-west-1)
+                [ $arch = 'amd64' ] && aki="aki-79a4c05a"
+                [ $arch = 'i386' ] && aki="aki-7ba4c058"
+        ;;
+        *) die "Unrecognized region:" "$region"
+esac
+
+
+[ $arch = 'i386' ] && ami_arch='i386'
+[ $arch = 'amd64' ] && ami_arch='x86_64'
+
+ami_name="$distribution-$codename-$arch-$name_suffix"
+log "Registering an AMI"
+ami_id=`euca-register "${bucketname}/${volume_id}.manifest.xml" \
+        --name "$ami_name" --description "$description" \
+        --architecture "$ami_arch" --kernel "$aki" \
+        | awk '{print $2}'`
+
+# If the user has already created an unnamed AMI today,
+# this will fail, so give the AMI registration command to the user
+if [[ ! "$ami_id" =~ ^ami-[0-9a-z]{8}$ ]]; then
+	die "Unable to register an AMI."
+#        die \
+#                "Unable to register an AMI." \
+#                "You can do it manually with:" \
+#                "`which euca-register` \\\\" \
+#                "--name '$ami_name' --description '$description' \\\\" \
+#                "--architecture '$ami_arch' --kernel '$aki' \\\\" \
+#                "--snapshot '$snapshot_id:$volume_size:true:standard'"
+fi
+log "Your AMI has been created with the ID '$ami_id'"
+

--- a/plugins/instance-store-ami-tasks/95-register-ami
+++ b/plugins/instance-store-ami-tasks/95-register-ami
@@ -46,7 +46,6 @@ esac
 [ $arch = 'i386' ] && ami_arch='i386'
 [ $arch = 'amd64' ] && ami_arch='x86_64'
 
-ami_name="$distribution-$codename-$arch-$name_suffix"
 log "Registering an AMI"
 ami_id=`euca-register \
         "${S3_BUCKET}/${ami_name}.manifest.xml" \


### PR DESCRIPTION
This plugin creates an instance-store based AMI instead of an EBS based one.
The main changes are :
- replaces all the tasks that deal with EBS volumes and use a local loop mounted image,
- install more recent euca2ools (2.1.3) (which requires python-boto >= 2.2, e.g. from squeeze-backports or wheezy)
- require additional AWS authentication information as environment variables (see task 08-more-host-info) and local files (key and cert).
