### PR TITLE
Vary APT mirror per cloud + make it configurable

### DIFF
--- a/build-debian-cloud
+++ b/build-debian-cloud
@@ -31,7 +31,6 @@ arch='amd64'
 locale='en_US'
 charmap='UTF-8'
 timezone='UTC'
-apt_mirror='http://http.debian.net/debian'
 
 # Hardcoded params.
 # This script would explode if we had to take care of other distributions

--- a/ec2
+++ b/ec2
@@ -7,6 +7,7 @@ description=
 snapshot_id=
 volume_id=
 volume_size='1'
+apt_mirror='http://http.debian.net/debian'
 
 # EC2 known regions
 known_regions=('us-east-1')
@@ -51,6 +52,7 @@ ${txtund}Bootstrapping${txtdef}
 
     --name SUFFIX                 AMI name suffix (${txtbld}${name_suffix}${txtdef})
     --description DESC            Description of the AMI
+    --apt-mirror URL              APT mirror URL (${txtbld}${apt_mirror}${txtdef})
 
 ${txtund}AWS${txtdef}
     --access-key ID               AWS Access Key (${txtbld}\$EC2_ACCESS_KEY${txtdef})
@@ -70,6 +72,7 @@ while [ $# -gt 0 ]; do
 		--volume-size)      volume_size=$2;                shift 2 ;;
 		--name)             name_suffix=$2;                shift 2 ;;
 		--description)      description=$2;                shift 2 ;;
+		--apt-mirror)       apt_mirror=$2;                 shift 2 ;;
 		--access-key)       EC2_ACCESS_KEY=$2;             shift 2 ;;
 		--secret-key)       EC2_SECRET_KEY=$2;             shift 2 ;;
 		--timezone)         timezone=$2;                   shift 2 ;;

--- a/gce
+++ b/gce
@@ -7,6 +7,7 @@ gce_project=
 # Image details
 image_name_suffix=$(date +%Y%m%d)
 volume_size='10'
+apt_mirror='http://gce_debian_mirror.storage.googleapis.com/'
 
 # List of options for gce subcommand
 help="build-debian-cloud gce
@@ -27,6 +28,7 @@ ${txtund}Bootstrapping${txtdef}
     --charmap CHARMAP             Standard charmap (${txtbld}${charmap}${txtdef})
 
     --name SUFFIX                 Image name suffix (${txtbld}${name_suffix}${txtdef})
+    --apt-mirror URL              APT mirror URL (${txtbld}${apt_mirror}${txtdef})
 
 ${txtund}GCE${txtdef}
     --gcs-dest URL                Google Cloud Storage image destination URL (${txtbld}${gcs_dest}${txtdef})
@@ -45,6 +47,7 @@ while [ $# -gt 0 ]; do
 		--filesystem)       filesystem=$2;                 shift 2 ;;
 		--volume-size)      volume_size=$2;                shift 2 ;;
 		--name)             name_suffix=$2;                shift 2 ;;
+		--apt-mirror)       apt_mirror=$2;                 shift 2 ;;
 		--gcs-dest)         gcs_dest=$2;                   shift 2 ;;
 		--gce-project)      gce_project=$2;                shift 2 ;;
 		--timezone)         timezone=$2;                   shift 2 ;;


### PR DESCRIPTION
Google is now running a Debian mirror inside Google Compute Engine so
that images within our cloud can save on bandwidth costs. Use it by
default for our images, without changing Amazon EC2.

Also make the mirror configurable with a new `--apt-mirror` option.
