### PR TITLE
Update Google image naming and descriptions & fix image addition

### DIFF
--- a/gce
+++ b/gce
@@ -5,9 +5,15 @@ gcs_dest=
 gce_project=
 
 # Image details
-image_name_suffix=$(date +%Y%m%d)
+image_name_suffix=v$(date +%Y%m%d)
+build_date=$(date +%Y-%m-%d)
 volume_size='10'
 apt_mirror='http://gce_debian_mirror.storage.googleapis.com/'
+kernel=projects/google/global/kernels/gce-v20130325
+
+# $description is set later if it has no value yet. This is
+# just for the help output.
+default_description="Debian GNU/Linux X.Y.Z (codename) built on YYYY-MM-DD"
 
 # List of options for gce subcommand
 help="build-debian-cloud gce
@@ -28,11 +34,13 @@ ${txtund}Bootstrapping${txtdef}
     --charmap CHARMAP             Standard charmap (${txtbld}${charmap}${txtdef})
 
     --name SUFFIX                 Image name suffix (${txtbld}${name_suffix}${txtdef})
+    --description DESC            Description of the image (${txtbld}${default_description}${txtdef})
     --apt-mirror URL              APT mirror URL (${txtbld}${apt_mirror}${txtdef})
 
 ${txtund}GCE${txtdef}
     --gcs-dest URL                Google Cloud Storage image destination URL (${txtbld}${gcs_dest}${txtdef})
     --gce-project PROJECT         Google Compute Engine image destination project (${txtbld}${gce_project}${txtdef})
+    --gce-kernel KERNEL           Google Compute Engine image kernel (${txtbld}${gce_kernel}${txtdef})
 
 ${txtund}Other options${txtdef}
     --debug                       Print debugging information
@@ -47,9 +55,11 @@ while [ $# -gt 0 ]; do
 		--filesystem)       filesystem=$2;                 shift 2 ;;
 		--volume-size)      volume_size=$2;                shift 2 ;;
 		--name)             name_suffix=$2;                shift 2 ;;
+		--description)      description=$2;                shift 2 ;;
 		--apt-mirror)       apt_mirror=$2;                 shift 2 ;;
 		--gcs-dest)         gcs_dest=$2;                   shift 2 ;;
 		--gce-project)      gce_project=$2;                shift 2 ;;
+		--gce-kernel)       gce_kernel=$2;                 shift 2 ;;
 		--timezone)         timezone=$2;                   shift 2 ;;
 		--locale)           locale=$2;                     shift 2 ;;
 		--charmap)          charmap=$2;                    shift 2 ;;

--- a/tasks/gce/01-packages-gce
+++ b/tasks/gce/01-packages-gce
@@ -2,3 +2,4 @@
 packages+=('python')
 packages+=('sudo')
 packages+=('ntp')
+packages+=('lsb-release')

--- a/tasks/gce/40-get-release-info
+++ b/tasks/gce/40-get-release-info
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+lsb_release="$(chroot $imagedir lsb_release -r -s)"
+lsb_description="$(chroot $imagedir lsb_release -d -s)"
+major_version=${lsb_release%%.*}

--- a/tasks/gce/75-compress-image
+++ b/tasks/gce/75-compress-image
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Create the compressed image file
 
-image_name="$distribution-$codename-$image_name_suffix.tar.gz"
-log "Creating $image_name."
-tar czSpf $workspace/$image_name -C $workspace disk.raw
+tarball_name="$distribution-$lsb_release-$codename-$image_name_suffix.tar.gz"
+log "Creating $tarball_name."
+tar czSpf $workspace/$tarball_name -C $workspace disk.raw

--- a/tasks/gce/80-save-image
+++ b/tasks/gce/80-save-image
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Move the image file out of our workspace
 
-log "Moving $image_name to $originaldir"
-mv $workspace/$image_name $originaldir
+log "Moving $tarball_name to $originaldir"
+mv $workspace/$tarball_name $originaldir

--- a/tasks/gce/95-register-image
+++ b/tasks/gce/95-register-image
@@ -5,16 +5,23 @@ if [ -z "${gcs_dest}" ]; then
   exit 0
 fi
 
-log "Uploading image to \"${gcs_dest}/${image_name}\""
-gsutil cp "${originaldir}/${image_name}" "${gcs_dest}/${image_name}"
+log "Uploading image to \"${gcs_dest}/${tarball_name}\""
+gsutil cp "${originaldir}/${tarball_name}" "${gcs_dest}/${tarball_name}"
 
 if [ -z "${gce_project}" ]; then
   log "No GCE destination project defined. Not adding the image."
   exit 0
 fi
 
-# GCE image name is the tarball name minus the suffix
-short_image_name="${image_name%.tar.gz}"
+# GCE image name is the tarball basename minus minor and patch versions
+image_name="$distribution-$major_version-$codename-$image_name_suffix"
 
-log "Adding image \"${short_image_name}\" to GCE project \"${gce_project}\""
-gcutil --project="${gce_project}" addimage "${short_image_name}" "${gcs_dest}/${image_name}"
+# Only set the description if it's not set yet
+if ! [[ -v description ]]; then
+  description="${lsb_description} built on ${build_date}"
+fi
+
+log "Adding image \"${image_name}\" to GCE project \"${gce_project}\""
+gcutil --project="${gce_project}" addimage "${image_name}" \
+  "${gcs_dest}/${tarball_name}" --description="${description}" \
+  --preferred_kernel="${gce_kernel}


### PR DESCRIPTION
This adjusts the naming scheme of image tarballs, adds a suitable version-specific description, and specifies a preferred kernel (can be overridden) for images so that automatic image addition works. Other than the preferred kernel, this could be adapted for non-Google clouds.
