### PR TITLE
Gcutil version bump in May 15 images

### DIFF
--- a/tasks/gce/25-install-gcutil
+++ b/tasks/gce/25-install-gcutil
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 wget -O $imagedir/tmp/gcutil.tar.gz \
-  https://google-compute-engine-tools.googlecode.com/files/gcutil-1.7.2.tar.gz
+  https://google-compute-engine-tools.googlecode.com/files/gcutil-1.8.0.tar.gz
 
 mkdir -p $imagedir/usr/local/share/google/gcutil
 tar xf $imagedir/tmp/gcutil.tar.gz -C $imagedir/usr/local/share/google/gcutil \


### PR DESCRIPTION
We pushed out one last set of Debian (and CentOS) images in connection with Google I/O, where a new gcutil was released. This is the corresponding gcutil version bump for build-debian-cloud.

The build also pulled in gsutil 3.29 and updated google-provided debs without needing any change to build-debian-cloud - those changes just fix things that were previously broken, like 'gsutil update' and running startup scripts stored in Google Cloud Storage, to name a couple, plus improvements to startup script logging. ("Startup script" here is the Google Compute Engine notion, not system sysvinit scripts.)

I think the pace of our PRs will slow to a more normal pace now. :)
