### PR TITLE
Bump default Compute Engine kernel

### DIFF
--- a/gce
+++ b/gce
@@ -9,7 +9,7 @@ image_name_suffix=v$(date +%Y%m%d)
 build_date=$(date +%Y-%m-%d)
 volume_size='10'
 apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
-gce_kernel=projects/google/global/kernels/gce-v20130325
+gce_kernel=projects/google/global/kernels/gce-v20130522
 
 # $description is set later if it has no value yet. This is
 # just for the help output.


### PR DESCRIPTION
New kernel went out today together with new images using it, dated
0522 (prep work was last week). The kernel fixes security issues, which
I believe have already been publicly reported and fixed in Debian
(unsure). This makes future Compute Engine images use it by default
when images are added via build-debian-cloud.

The images were built with the previous commit, and the new kernel was
simply specified to gcutil addimage. No other changes to
build-debian-cloud were included, though Google's debs were revised to
improve network performance by configuring irq affinities via /proc at
startup. (We're planning to work on getting the necessary irqbalance
tweak into wheezy via stable-proposed-updates and then switch from
manual tweaks to installing irqbalance.)
