### PR TITLE
Version bumps for 0723 Google Compute Engine images

### DIFF
--- a/gce
+++ b/gce
@@ -9,7 +9,7 @@ image_name_suffix=v$(date +%Y%m%d)
 build_date=$(date +%Y-%m-%d)
 volume_size='10'
 apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
-gce_kernel=projects/google/global/kernels/gce-v20130522
+gce_kernel=projects/google/global/kernels/gce-v20130603
 
 # $description is set later if it has no value yet. This is
 # just for the help output.

--- a/tasks/gce/25-install-gcutil
+++ b/tasks/gce/25-install-gcutil
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 wget -O $imagedir/tmp/gcutil.tar.gz \
-  https://google-compute-engine-tools.googlecode.com/files/gcutil-1.8.1.tar.gz
+  https://google-compute-engine-tools.googlecode.com/files/gcutil-1.8.2.tar.gz
 
 mkdir -p $imagedir/usr/local/share/google/gcutil
 tar xf $imagedir/tmp/gcutil.tar.gz -C $imagedir/usr/local/share/google/gcutil \


### PR DESCRIPTION
At build time, also pulled in versions 1.0.4-1 of Google-specific debs from Google's repository, and gsutil 3.34.
