### PR TITLE
ec2/11-attach-volume: Wait for volume to be available

### DIFF
--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -8,6 +8,8 @@ for device_letter in {f..z}; do
 done
 [ -b $device_path ] && die "No free device letters found (tried sdf to sdz)!"
 
+# Wait until the volume is available
+dotdot "euca-describe-volumes $volume_id | grep available"
 euca-attach-volume --instance "$instance_id" --device "/dev/sd$device_letter" "$volume_id"
 # Wait until the volume is attached
 dotdot "test -b $device_path && echo attached"


### PR DESCRIPTION
When creating a new volume on EC2, the volume starts out in state "creating"
before becoming "available". euca-attach-volume will not attach the volume if
the state is not available, resulting in the following output:

```
Run task: 10-create-volume
The EBS volume id is vol-deadbeef
Run task: 11-attach-volume
IncorrectState: vol-deadbeef is not 'available'.
```

The script then hangs forever waiting for the volume to be attached, which will never happen.

Waiting until the volume is available before trying to attach it solved this problem (see attached commit).
