### PR TITLE
Chmod the seded file back to being executable.

### DIFF
--- a/plugins/admin_user/tasks.py
+++ b/plugins/admin_user/tasks.py
@@ -52,6 +52,11 @@ class AdminUserCredentials(Task):
 		getcreds_path = os.path.join(info.root, 'etc/init.d/ec2-get-credentials')
 		username = info.manifest.plugins['admin_user']['username']
 		sed_i(getcreds_path, 'username=\'root\'', 'username=\'{username}\''.format(username=username))
+		import stat
+		rwxr_xr_x = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                             stat.S_IRGRP                | stat.S_IXGRP |
+                             stat.S_IROTH                | stat.S_IXOTH)
+		os.chmod(getcreds_path, rwxr_xr_x)
 
 
 class DisableRootLogin(Task):


### PR DESCRIPTION
Chmod the get-ec2-credentials file after we sed it in the case of the admin_user being used.
