### PR TITLE
Plugin for adding backports to apt and a set of packages from backports.

### DIFF
--- a/manifests/ec2-ebs-pvm.manifest.json
+++ b/manifests/ec2-ebs-pvm.manifest.json
@@ -31,6 +31,10 @@
 			"enabled": true,
 			"username": "admin"
 		},
+		"backports": {
+			"enabled": true,
+			"packages": [ "cloud-init" ]
+		},
 		"build_metadata": {
 			"enabled": false,
 			"path":    "/root/build-metadata-{ami_name}"

--- a/plugins/backports/__init__.py
+++ b/plugins/backports/__init__.py
@@ -1,0 +1,12 @@
+
+
+def tasks(tasklist, manifest):
+	import tasks
+	tasklist.add(tasks.AptSourcesBackports())
+	tasklist.add(tasks.AddBackportsPackages())
+
+
+def validate_manifest(data, schema_validate):
+	from os import path
+	schema_path = path.normpath(path.join(path.dirname(__file__), 'manifest-schema.json'))
+	schema_validate(data, schema_path)

--- a/plugins/backports/manifest-schema.json
+++ b/plugins/backports/manifest-schema.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Backports setup and package install",
+	"type": "object",
+	"properties": {
+		"plugins": {
+			"type": "object",
+			"properties": {
+				"backports": {
+					"type": "object",
+					"properties": {
+						"packages": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					},
+					"required": ["packages"]
+				}
+			},
+			"required": ["backports"]
+		}
+	},
+	"required": ["plugins"]
+}

--- a/plugins/backports/tasks.py
+++ b/plugins/backports/tasks.py
@@ -1,0 +1,38 @@
+from base import Task
+from common import phases
+from common.tasks.packages import ImagePackages
+from common.tasks.initd import InstallInitScripts
+from common.tasks.apt import AptUpgrade
+from common.tasks.apt import AptSources
+import os
+
+
+class AptSourcesBackports(Task):
+        description = 'Adding backports to sources.list'
+        phase = phases.system_modification
+	after = [AptSources]
+	before = [AptUpgrade]
+        def run(self, info):
+                sources_path = os.path.join(info.root, 'etc/apt/sources.list')
+                with open(sources_path, 'a') as apt_sources:
+                        apt_sources.write(('deb     {apt_mirror} {release}-backports main\n'
+                                           'deb-src {apt_mirror} {release}-backports main\n'
+                                          .format(apt_mirror='http://http.debian.net/debian',
+                                                release=info.manifest.system['release'])))
+
+
+class AddBackportsPackages(Task):
+        description = 'Adding backport packages to the image'
+        phase = phases.system_modification
+        after = [AptUpgrade]
+
+
+        def run(self, info):
+                if 'packages' not in info.manifest.plugins['backports']:
+                        return
+
+                from shutil import copy
+                from common.tools import log_check_call
+
+                for pkg in info.manifest.plugins['backports']['packages']:
+                        log_check_call(['/usr/sbin/chroot', info.root, 'apt-get', 'install', '-y', '-t', info.manifest.system['release'] + '-backports', pkg])


### PR DESCRIPTION
Plugin for turning on backports in apt's sources.list, and installing packages from it (eg, cloud-init in Wheezy).
