### PR TITLE
Commit corresponding to Google 20130816 images

### DIFF
--- a/gce
+++ b/gce
@@ -9,7 +9,7 @@ image_name_suffix=v$(date +%Y%m%d)
 build_date=$(date +%Y-%m-%d)
 volume_size='10'
 apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
-gce_kernel=projects/google/global/kernels/gce-v20130603
+gce_kernel=projects/google/global/kernels/gce-v20130813
 
 # $description is set later if it has no value yet. This is
 # just for the help output.

--- a/tasks/gce/21-apt-sources-goog
+++ b/tasks/gce/21-apt-sources-goog
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Basic sources.list
+# Basic sources.list. The current packages work on all supported versions of
+# Debian, so at least for now we're using a distribution name independent of
+# those.
 cat > $imagedir/etc/apt/sources.list.d/goog.list <<EOF
-deb     http://goog-repo.appspot.com/ /
+deb     http://goog-repo.appspot.com/debian pigeon main
 EOF

--- a/tasks/gce/25-install-gce-debs
+++ b/tasks/gce/25-install-gce-debs
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Add GCE startup scripts and packages to the image.
 
-DEBS="google-compute-daemon google-startup-scripts image-bundle"
+DEBS="google-compute-daemon google-startup-scripts image-bundle gcutil"
 for deb in $DEBS; do
   chroot $imagedir apt-get install --force-yes -y ${deb}
 done

--- a/tasks/gce/25-install-gcutil
+++ b/tasks/gce/25-install-gcutil
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-wget -O $imagedir/tmp/gcutil.tar.gz \
-  https://google-compute-engine-tools.googlecode.com/files/gcutil-1.8.2.tar.gz
-
-mkdir -p $imagedir/usr/local/share/google/gcutil
-tar xf $imagedir/tmp/gcutil.tar.gz -C $imagedir/usr/local/share/google/gcutil \
-  --strip-components=1
-ln -s ../share/google/gcutil/gcutil $imagedir/usr/local/bin/gcutil


### PR DESCRIPTION
Overdue PR here: This revision of the repository was used for the v20130816 Google Compute Engine images, which after testing (delayed for unrelated reasons) were published on September 4.

Google's APT repository had not yet been GPG-signed, though it is now, so these commits don't work any more. I have another commit ready that adds handling for Google's GPG key, but to keep this PR cleanly matching the 20130816 images I'll leave that for a subsequent PR.
