### PR TITLE
Two Google Compute Engine fixes: one bugfix, one future prep

### DIFF
--- a/tasks/01-packages
+++ b/tasks/01-packages
@@ -8,6 +8,8 @@ packages+=('locales')
 # Needed for the init scripts
 packages+=('file')
 
+packages+=('grub-pc')
+
 # We will need to format the volume, so we need xfsprogs
 [ $filesystem = 'xfs' ] && host_packages+=('xfsprogs')
 # In order to make sure a volume is not busy, before unmounting we need lsof

--- a/tasks/ec2/01-packages-ec2
+++ b/tasks/ec2/01-packages-ec2
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Add some basic packages we are going to need
-packages+=('grub-pc')
 
 # Apparently isc-dhcp-client doesn't work properly with ec2
 packages+=('dhcpcd')

--- a/tasks/gce/09-create-workspace
+++ b/tasks/gce/09-create-workspace
@@ -19,9 +19,6 @@ function cleanup_loopback_mount () {
 
   if [ -n "$base_device_path" ]; then
     log "Deleting whole-disk loopback device $base_device_path ahead of unclean exit."
-    # A complete cleanup job involves both kpartx and losetup. Whatever we can
-    # clean up is best.
-    kpartx -d $base_device_path
     losetup -d $base_device_path
   fi
 

--- a/tasks/gce/09-create-workspace
+++ b/tasks/gce/09-create-workspace
@@ -13,8 +13,16 @@ function cleanup_loopback_mount () {
   fi
 
   if [ -n "$device_path" ]; then
-    log "Deleting loopback device $device_path ahead of unclean exit."
+    log "Deleting partition loopback device $device_path ahead of unclean exit."
     losetup -d $device_path
+  fi
+
+  if [ -n "$base_device_path" ]; then
+    log "Deleting whole-disk loopback device $base_device_path ahead of unclean exit."
+    # A complete cleanup job involves both kpartx and losetup. Whatever we can
+    # clean up is best.
+    kpartx -d $base_device_path
+    losetup -d $base_device_path
   fi
 
   if [ -d "$workspace" ]; then

--- a/tasks/gce/11-create-loopback
+++ b/tasks/gce/11-create-loopback
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Set up loopback device
+# Set up loopback devices.
 
-device_path="$(losetup -f)"
+# First the underlying disk...
+base_device_path="$(losetup -f --show $workspace/disk.raw)"
 
-if ! losetup -o "$((1024*1024))" "${device_path}" $workspace/disk.raw; then
+if [ $? -ne 0 ]; then
   die "Unable to create volume."
 fi
 
-log "Loopback device for GCE volume is ${device_path}."
+log "Whole-disk loopback device for GCE volume is ${base_device_path}."
+
+# ... then the partition at a 1MB offset. (Avoid the kpartx + /dev/mapper combo
+# due to GRUB tools being finicky.)
+device_path="$(losetup -o $((1024*1024)) -f --show ${base_device_path})"
+log "Partition loopback device for GCE volume is ${device_path}."

--- a/tasks/gce/21-apt-sources-goog
+++ b/tasks/gce/21-apt-sources-goog
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Basic sources.list. The current packages work on all supported versions of
 # Debian, so at least for now we're using a distribution name independent of
-# those.
+# those. The repository is GPG signed, so temporarily import the key.
+wget -O - https://goog-repo.appspot.com/debian/key/public.gpg.key | chroot $imagedir apt-key add -
 cat > $imagedir/etc/apt/sources.list.d/goog.list <<EOF
 deb     http://goog-repo.appspot.com/debian pigeon main
 EOF

--- a/tasks/gce/26-remove-goog-apt-source
+++ b/tasks/gce/26-remove-goog-apt-source
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-# The repository is not yet GPG-signed and has a hostname which end users might
-# not expect to host an official Google package repository, especially after apt
-# prompts them with an "unauthenticated packages" warning. To ensure user
-# confidence without training them to ignore warnings, remove the extra apt
-# source before finalizing the image.
+# To be as close to stock Debian as possible, the image should default to the
+# standard Debian repository list. Therefore, remove the Google repository and
+# GPG key, then update the apt cache once more.
 
 rm $imagedir/etc/apt/sources.list.d/goog.list
+google_keyid="$(chroot $imagedir apt-key adv --with-colons --list-keys \
+  | awk -F: '$10 ~ /@google\.com/ { print $5 }')"
+chroot $imagedir apt-key del ${google_keyid}
 chroot $imagedir apt-get update

--- a/tasks/gce/30-grub
+++ b/tasks/gce/30-grub
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Prepare GRUB to install itself correctly.
+
+# Set up a device map for GRUB to use while loopback-mounted:
+echo "(hd0) ${base_device_path}" > $imagedir/boot/grub/device.map
+echo "(hd0,1) ${device_path}" >> $imagedir/boot/grub/device.map
+
+# Configure GRUB timeouts for fast booting:
+sed -i -e '/GRUB_TIMEOUT=/s/^.*/GRUB_TIMEOUT=0/' $imagedir/etc/default/grub
+
+# Direct GRUB and Linux console output to ttyS0 to facilitate gcutil
+# getserialportoutput.
+#
+# The backreference on the next line avoids spurious spaces in the resulting
+# kernel command line.
+sed -i -e '/GRUB_CMDLINE_LINUX=/s/\( \)\?"$/\1console=ttyS0,38400n8"/' \
+    $imagedir/etc/default/grub
+sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"' \
+    $imagedir/etc/default/grub

--- a/tasks/gce/32-install-kernel
+++ b/tasks/gce/32-install-kernel
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Google Compute Engine doesn't use Xen, so all working versions of Debian use
+# the 'linux-image-$flavor' package.
+[ $arch = 'amd64' ] && kernel_package='linux-image-amd64'
+[ $arch = 'i386' ] && kernel_package='linux-image-686'
+
+chroot $imagedir apt-get -y --no-install-recommends ${kernel_install_opts} install ${kernel_package}

--- a/tasks/gce/70-finalize-grub
+++ b/tasks/gce/70-finalize-grub
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Install GRUB in the MBR of the image and do necessary cleanup
+
+# Install GRUB:
+chroot $imagedir grub-install "${base_device_path}"
+
+# Remove loopback-specific device map:
+rm $imagedir/boot/grub/device.map
+
+# Remove loopback-specific grub.cfg lines added by a Debian/Ubuntu GRUB patch
+# meant for a different use case:
+sed -i -e '/loop/d' $imagedir/boot/grub/grub.cfg

--- a/tasks/gce/73-delete-loopback
+++ b/tasks/gce/73-delete-loopback
@@ -1,7 +1,11 @@
 #!/bin/bash
-# Delete the loopback device
-log "Deleting the loopback device"
+# Delete the loopback devices
+log "Deleting the loopback devices"
 losetup -d $device_path
+# Give the system a moment to react to the first losetup -d, without which the
+# second losetup -d gives a fatal "Device or resource busy" error.
+sleep 1
+losetup -d $base_device_path
 
 # Lets cleanup code know the loopback device was deleted.
-unset device_path
+unset device_path base_device_path


### PR DESCRIPTION
For once I'm pushing commits before we put them into an image!
- "Handle GPG key for Compute Engine apt repository": The repository was unsigned as of when we built our August 16 Debian image (and that tarball was reused with a different kernel for the September 26 image), so it wasn't necessary for our published builds so far. Since we started signing it, private builds might have broken without handling the key. This will also enable future public builds to work.
- "Compute Engine: prepare for Debian kernel support": Mostly self-explanatory purpose. :) The images still use a Google-injected kernel until the feature launches.
  - I also submitted a third commit updating this preparatory commit to remove some accidentally included cleanup code relating to kpartx, since despite some internal experiments I didn't end up introducing a kpartx dependency into the script after all.
