### PR TITLE
if tmp contains directories, cleanup task fails. Add management for directories too

### DIFF
--- a/common/tasks/cleanup.py
+++ b/common/tasks/cleanup.py
@@ -1,6 +1,7 @@
 from base import Task
 from common import phases
 import os
+import shutil
 
 
 class ClearMOTD(Task):
@@ -36,7 +37,10 @@ class CleanTMP(Task):
 	def run(self, info):
 		tmp = os.path.join(info.root, 'tmp')
 		for tmp_file in [os.path.join(tmp, f) for f in os.listdir(tmp)]:
-			os.remove(tmp_file)
+			if os.path.isfile(tmp_file):
+				os.remove(tmp_file)
+			else:
+				shutil.rmtree(tmp_file)
 
 		log = os.path.join(info.root, 'var/log/')
 		os.remove(os.path.join(log, 'bootstrap.log'))


### PR DESCRIPTION
Fix when tmp dir contains directories
