### PR TITLE
 fix call of ImageCommands

### DIFF
--- a/plugins/image_commands/README.md
+++ b/plugins/image_commands/README.md
@@ -14,11 +14,9 @@ Command is executed in current context. It is possible to use variables to acces
 
 Available variables are:
   {root} : image mount point (to copy files for example or chroot commands)
-  {filesystem}    : used filesystem
-  {image} : image file path
 
 Example:
 
     [[ "touch", "{root}/var/www/hello" ],
-    [ "/usr/sbin/chroot", "{root}", "touch", "/var/www/hello.{filesystem}"]]
+    [ "/usr/sbin/chroot", "{root}", "touch", "/var/www/hello"]]
 

--- a/plugins/image_commands/__init__.py
+++ b/plugins/image_commands/__init__.py
@@ -2,10 +2,10 @@
 
 def tasks(tasklist, manifest):
         from image_commands import ImageExecuteCommand
-        tasklist.add(ImageExecuteCommand())
+        tasklist.add(ImageExecuteCommand)
+
 
 def validate_manifest(data, schema_validate):
         from os import path
         schema_path = path.normpath(path.join(path.dirname(__file__), 'manifest-schema.json'))
         schema_validate(data, schema_path)
-

--- a/plugins/image_commands/image_commands.py
+++ b/plugins/image_commands/image_commands.py
@@ -1,22 +1,19 @@
 from base import Task
 from common import phases
+from plugins.user_packages.user_packages import AddUserPackages, \
+                                                AddLocalUserPackages
 
 
 class ImageExecuteCommand(Task):
     description = 'Execute command in the image'
     phase = phases.system_modification
+    predecessors = [AddUserPackages, AddLocalUserPackages]
 
     def run(self, info):
         from common.tools import log_check_call
-
         for user_cmd in info.manifest.plugins['image_commands']['commands']:
             command = []
             for elt in user_cmd:
-                fragment = elt.format(
-                                root=info.root,
-                                image=info.loopback_file,
-                                filesystem=info.manifest.volume['filesystem'])
-                command.append(fragment) 
+                fragment = elt.format(root=info.root)
+                command.append(fragment)
             log_check_call(command)
-
-


### PR DESCRIPTION
Various fixes to adapt to latests modifications in base files.

  remove loopback_file reference, not existing anymore
  filesystem not available anymore, and depends on volume layout so remove the
  execute commands after the user_packages install, else user won't be able to
  call or update installed packages
