### PR TITLE
Install packages after debootstrap 

### DIFF
--- a/common/tasks/apt.py
+++ b/common/tasks/apt.py
@@ -15,7 +15,7 @@ class AptSources(Task):
 		with open(sources_path, 'w') as apt_sources:
 			apt_sources.write(('deb     {apt_mirror} {release} main\n'
 			                   'deb-src {apt_mirror} {release} main\n'
-			                   .format(apt_mirror='http://http.debian.net/debian',
+			                   .format(apt_mirror=info.manifest.bootstrapper['mirror'],
 			                           release=info.manifest.system['release'])))
 			apt_sources.write(('deb     {apt_mirror} {release}/updates main\n'
 			                   'deb-src {apt_mirror} {release}/updates main\n'

--- a/plugins/user_packages/__init__.py
+++ b/plugins/user_packages/__init__.py
@@ -4,3 +4,9 @@ def tasks(tasklist, manifest):
 	from user_packages import AddUserPackages, AddLocalUserPackages
 	tasklist.add(AddUserPackages,
 	             AddLocalUserPackages)
+
+
+def validate_manifest(data, schema_validate):
+        from os import path
+        schema_path = path.normpath(path.join(path.dirname(__file__), 'manifest-schema.json'))
+        schema_validate(data, schema_path)

--- a/plugins/user_packages/manifest-schema.json
+++ b/plugins/user_packages/manifest-schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Image commands plugin manifest",
+	"type": "object",
+	"properties": {
+		"plugins": {
+			"type": "object",
+			"properties": {
+				"user_packages": {
+					"type": "object",
+					"properties": {
+ 						"repo": {
+							"type": "array",
+							"items": { "type": "string" }
+						},
+						"local": {
+							"type": "array",
+							"items": { "type": "string" }
+						}
+					}
+				}
+			},
+			"required": ["user_packages"]
+		}
+	},
+	"required": ["plugins"]
+}


### PR DESCRIPTION
because debootstrap does not support all packages, and fails at config time for a few. Closes #119

Packages are installed at system modification
Install local packages after repo ones

Also sets apt mirror to the one defined by bootstrapper to download
 packages from same location.
