### PR TITLE
Permit cloud-init to be configured for its metadata sources using debcon...

### DIFF
--- a/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
@@ -10,8 +10,8 @@
 		"workspace": "/target"
 	},
 	"image": {
-		"name":        "debian-{release}-{architecture}-{virtualization}-{%y}{%m}{%d}",
-		"description": "Debian {release} {architecture} AMI ({virtualization})"
+		"name":        "debian-{release}-{architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {release} {architecture}"
 	},
 	"system": {
 		"release":      "wheezy",

--- a/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
@@ -44,7 +44,8 @@
 			]
 		},
 		"cloud_init": {
-			"username": "admin"
+			"username": "admin",
+			"metadata_sources": "Ec2"
 		}
 	}
 }

--- a/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.json
@@ -45,7 +45,8 @@
 		},
 		"cloud_init": {
 			"username": "admin",
-			"metadata_sources": "Ec2"
+			//"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
 		}
 	}
 }

--- a/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
@@ -10,8 +10,8 @@
 		"workspace": "/target"
 	},
 	"image": {
-		"name":        "debian-{release}-{architecture}-{virtualization}-{%y}{%m}{%d}",
-		"description": "Debian {release} {architecture} AMI ({virtualization})"
+		"name":        "debian-{release}-{architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {release} {architecture}"
 	},
 	"system": {
 		"release":      "wheezy",

--- a/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
@@ -44,7 +44,8 @@
 			]
 		},
 		"cloud_init": {
-			"username": "admin"
+			"username": "admin",
+			"metadata_sources": "Ec2"
 		}
 	}
 }

--- a/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-amd64-pvm.manifest.json
@@ -45,7 +45,8 @@
 		},
 		"cloud_init": {
 			"username": "admin",
-			"metadata_sources": "Ec2"
+			//"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
 		}
 	}
 }

--- a/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
@@ -10,8 +10,8 @@
 		"workspace": "/target"
 	},
 	"image": {
-		"name":        "debian-{release}-{architecture}-{virtualization}-{%y}{%m}{%d}",
-		"description": "Debian {release} {architecture} AMI ({virtualization})"
+		"name":        "debian-{release}-{architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {release} {architecture}"
 	},
 	"system": {
 		"release":      "wheezy",

--- a/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
@@ -45,7 +45,8 @@
 		},
 		"cloud_init": {
 			"username": "admin",
-                        "metadata_sources": "Ec2"
+                        //"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
 		}
 	}
 }

--- a/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-official-i386-pvm.manifest.json
@@ -44,7 +44,8 @@
 			]
 		},
 		"cloud_init": {
-			"username": "admin"
+			"username": "admin",
+                        "metadata_sources": "Ec2"
 		}
 	}
 }

--- a/plugins/cloud_init/__init__.py
+++ b/plugins/cloud_init/__init__.py
@@ -23,9 +23,11 @@ def validate_manifest(data, schema_validate):
 def resolve_tasks(tasklist, manifest):
 	from tasks import SetUsername
 	from tasks import SetMetadataSource
+	from tasks import AutoSetMetadataSource
+	from tasks import DisableModules
 	from providers.ec2.tasks.initd import AddEC2InitScripts
 	from common.tasks import initd
-	tasklist.add(SetUsername, SetMetadataSource)
+	tasklist.add(SetUsername, AutoSetMetadataSource, SetMetadataSource, DisableModules)
 	tasklist.remove(AddEC2InitScripts,
 	                initd.AddExpandRoot,
 	                initd.AdjustExpandRootScript,

--- a/plugins/cloud_init/__init__.py
+++ b/plugins/cloud_init/__init__.py
@@ -27,7 +27,16 @@ def resolve_tasks(tasklist, manifest):
 	from tasks import DisableModules
 	from providers.ec2.tasks.initd import AddEC2InitScripts
 	from common.tasks import initd
-	tasklist.add(SetUsername, AutoSetMetadataSource, SetMetadataSource, DisableModules)
+
+	options = manifest.plugins['cloud_init']
+	tasklist.add(AutoSetMetadataSource)
+	if 'username' in options:
+		tasklist.add(SetUsername)
+	if 'disable_modules' in options:
+		tasklist.add(DisableModules)
+	if 'metadata_sources' in options:
+		tasklist.add(SetMetadataSource)
+
 	tasklist.remove(AddEC2InitScripts,
 	                initd.AddExpandRoot,
 	                initd.AdjustExpandRootScript,

--- a/plugins/cloud_init/__init__.py
+++ b/plugins/cloud_init/__init__.py
@@ -22,9 +22,10 @@ def validate_manifest(data, schema_validate):
 
 def resolve_tasks(tasklist, manifest):
 	from tasks import SetUsername
+	from tasks import SetMetadataSource
 	from providers.ec2.tasks.initd import AddEC2InitScripts
 	from common.tasks import initd
-	tasklist.add(SetUsername)
+	tasklist.add(SetUsername, SetMetadataSource)
 	tasklist.remove(AddEC2InitScripts,
 	                initd.AddExpandRoot,
 	                initd.AdjustExpandRootScript,

--- a/plugins/cloud_init/manifest-schema.json
+++ b/plugins/cloud_init/manifest-schema.json
@@ -12,6 +12,13 @@
 						"username": {
 							"type": "string"
 						},
+						"disable_modules": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							},
+							"uniqueItems": true
+						},
 						"metadata_sources": {
 							"type": "string"
 						}

--- a/plugins/cloud_init/manifest-schema.json
+++ b/plugins/cloud_init/manifest-schema.json
@@ -11,6 +11,9 @@
 					"properties": {
 						"username": {
 							"type": "string"
+						},
+						"metadata_sources": {
+							"type": "string"
 						}
 					},
 					"required": ["username"]

--- a/plugins/cloud_init/tasks.py
+++ b/plugins/cloud_init/tasks.py
@@ -45,6 +45,7 @@ class AutoSetMetadataSource(Task):
 		  sources = "Ec2"
 
 		if sources:
+		  print ("Setting metadata source to " + sources)
 		  sources = "cloud-init      cloud-init/datasources  multiselect     " + sources
 		  log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections' ], sources)
 
@@ -54,22 +55,22 @@ class DisableModules(Task):
 	predecessors = [apt.AptUpgrade]
 
 	def run(self, info):
-		patterns = ""
-		for pattern in info.manifest.plugins['cloud_init']['disable_modules']:
-		  if patterns != "":
-		    patterns = patterns + "|" + pattern
-		  else:
-		    patterns = "^\s+-\s+(" + pattern
-		patterns = patterns + ")$"
-		regex = re.compile(patterns)
+		if 'disable_modules' in info.manifest.plugins['cloud_init']:
+		  patterns = ""
+		  for pattern in info.manifest.plugins['cloud_init']['disable_modules']:
+		    if patterns != "":
+		      patterns = patterns + "|" + pattern
+		    else:
+		      patterns = "^\s+-\s+(" + pattern
+		  patterns = patterns + ")$"
+		  regex = re.compile(patterns)
 
-		f = open(info.root + "/etc/cloud/cloud.cfg")
-		lines = f.readlines()
-		f.close()
+		  f = open(info.root + "/etc/cloud/cloud.cfg")
+		  lines = f.readlines()
+		  f.close()
 
-		print("Pattern to match is " + patterns + "\n")
-		f = open(info.root + "/etc/cloud/cloud.cfg", "w")
-		for line in lines:
+		  f = open(info.root + "/etc/cloud/cloud.cfg", "w")
+		  for line in lines:
 		    if not regex.match(line):
 		      f.write(line)
-		f.close
+		  f.close

--- a/plugins/cloud_init/tasks.py
+++ b/plugins/cloud_init/tasks.py
@@ -22,6 +22,7 @@ class SetUsername(Task):
 		           '     shell: /bin/bash').format(username=username)
 		sed_i(cloud_cfg, search, replace)
 
+
 class SetMetadataSource(Task):
         description = 'Setting metadata source'
         phase = phases.system_modification
@@ -31,7 +32,7 @@ class SetMetadataSource(Task):
         def run(self, info):
 		if "metadata_sources" in info.manifest.plugins['cloud_init']:
 		    sources = "cloud-init      cloud-init/datasources  multiselect     " + info.manifest.plugins['cloud_init']['metadata_sources']
-		    log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections' ], sources)
+		    log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections'], sources)
 
 
 class AutoSetMetadataSource(Task):
@@ -39,6 +40,7 @@ class AutoSetMetadataSource(Task):
         phase = phases.system_modification
 	predecessors = [apt.AptSources]
         successors = [SetMetadataSource]
+
 	def run(self, info):
 		sources = ""
 		if info.manifest.provider == "ec2":
@@ -47,7 +49,8 @@ class AutoSetMetadataSource(Task):
 		if sources:
 		  print ("Setting metadata source to " + sources)
 		  sources = "cloud-init      cloud-init/datasources  multiselect     " + sources
-		  log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections' ], sources)
+		  log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections'], sources)
+
 
 class DisableModules(Task):
 	description = 'Setting cloud.cfg modules'

--- a/plugins/cloud_init/tasks.py
+++ b/plugins/cloud_init/tasks.py
@@ -1,6 +1,8 @@
 from base import Task
 from common import phases
 from plugins.packages.tasks import InstallRemotePackages
+from common.tasks import apt
+from common.tools import log_check_call
 
 
 class SetUsername(Task):
@@ -18,3 +20,14 @@ class SetUsername(Task):
 		           '     sudo: ALL=(ALL) NOPASSWD:ALL\n'
 		           '     shell: /bin/bash').format(username=username)
 		sed_i(cloud_cfg, search, replace)
+
+class SetMetadataSource(Task):
+        description = 'Setting metadata source'
+        phase = phases.system_modification
+	predecessors = [apt.AptSources]
+        successors = [apt.AptUpdate]
+
+        def run(self, info):
+		sources = "cloud-init      cloud-init/datasources  multiselect     " + info.manifest.plugins['cloud_init']['metadata_sources']
+		log_check_call(['/usr/sbin/chroot', info.root, '/usr/bin/debconf-set-selections' ], sources)
+

--- a/plugins/cloud_init/tasks.py
+++ b/plugins/cloud_init/tasks.py
@@ -68,9 +68,13 @@ class DisableModules(Task):
 		  patterns = patterns + ")$"
 		  regex = re.compile(patterns)
 
-		  f = open(info.root + "/etc/cloud/cloud.cfg")
-		  lines = f.readlines()
-		  f.close()
+		  try:
+		    f = open(info.root + "/etc/cloud/cloud.cfg")
+		    lines = f.readlines()
+		    f.close()
+		  except:
+		    print "Cannot read cloud.cfg"
+		    return -1
 
 		  f = open(info.root + "/etc/cloud/cloud.cfg", "w")
 		  for line in lines:


### PR DESCRIPTION
This should permit the user to specify a metadata_source in the cloud_init plugin, so they can optimise to just the current environment.
