### PR TITLE
Add ability to create unstable images

### DIFF
--- a/base/manifest-schema.json
+++ b/base/manifest-schema.json
@@ -25,7 +25,7 @@
 		"system": {
 			"type": "object",
 			"properties": {
-				"release":      { "enum": ["wheezy"] },
+				"release":      { "enum": ["wheezy", "unstable"] },
 				"architecture": { "enum": ["i386", "amd64"] },
 				"bootloader":   { "enum": ["pvgrub", "grub", "extlinux"] },
 				"timezone":     { "type": "string" },

--- a/common/tasks/apt.py
+++ b/common/tasks/apt.py
@@ -25,8 +25,9 @@ class AddDefaultSources(Task):
 	def run(cls, info):
 		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} main')
 		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} main')
-		info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates main')
-		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates main')
+		if info.manifest.system['release'] != 'unstable':
+			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates main')
+			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates main')
 
 
 class InstallTrustedKeys(Task):

--- a/common/tasks/network-configuration.json
+++ b/common/tasks/network-configuration.json
@@ -1,0 +1,13 @@
+{
+	"squeeze": [
+		"auto lo\n",
+		"iface lo inet loopback\n",
+		"auto eth0\n",
+		"iface eth0 inet dhcp\n" ],
+	"wheezy": [
+		"auto eth0\n", 
+		"iface eth0 inet dhcp\n" ],
+	"unstable": [
+		"auto eth0\n",
+		"iface eth0 inet dhcp\n" ]
+}

--- a/common/tasks/network.py
+++ b/common/tasks/network.py
@@ -30,11 +30,9 @@ class ConfigureNetworkIF(Task):
 	@classmethod
 	def run(cls, info):
 		interfaces_path = os.path.join(info.root, 'etc/network/interfaces')
-		if_config = {'squeeze': ('auto lo\n'
-		                         'iface lo inet loopback\n'
-		                         'auto eth0\n'
-		                         'iface eth0 inet dhcp\n'),
-		             'wheezy':  'auto eth0\n'
-		                        'iface eth0 inet dhcp\n'}
+		if_config = []
+		with open('common/tasks/network-configuration.json') as stream:
+			import json
+			if_config = json.loads(stream.read())
 		with open(interfaces_path, 'a') as interfaces:
-			interfaces.write(if_config.get(info.manifest.system['release']))
+			interfaces.write(''.join(if_config.get(info.manifest.system['release'])))

--- a/manifests/ec2-ebs-debian-unstable-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-unstable-amd64-pvm.manifest.json
@@ -1,0 +1,44 @@
+{
+	"provider":       "ec2",
+	"virtualization": "pvm",
+	"credentials":    {
+		// "access-key": null,
+		// "secret-key": null
+	},
+
+	"bootstrapper": {
+		"workspace": "/target"
+	},
+	"image": {
+		"name":        "debian-{system.release}-{system.architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {system.release} {system.architecture}"
+	},
+	"system": {
+		"release":      "unstable",
+		"architecture": "amd64",
+		"bootloader":   "pvgrub",
+		"timezone":     "UTC",
+		"locale":       "en_US",
+		"charmap":      "UTF-8"
+	},
+	"packages": {
+		"mirror": "http://cloudfront.debian.net/debian"
+	},
+	"volume": {
+		"backing": "ebs",
+		"partitions": {
+			"type": "none",
+			"root": {
+				"size":       8192,
+				"filesystem": "ext4"
+			}
+		}
+	},
+	"plugins": {
+		"cloud_init": {
+			"username": "admin",
+			//"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
+		}
+	}
+}

--- a/providers/ec2/tasks/packages-kernels.json
+++ b/providers/ec2/tasks/packages-kernels.json
@@ -1,0 +1,11 @@
+{
+	"squeeze": {
+		"amd64": "linux-image-xen-amd64",
+		"i386" : "linux-image-xen-686" },
+	"wheezy": {
+		"amd64": "linux-image-amd64",
+	      	"i386" :  "linux-image-686" },
+	"unstable": {
+		"amd64": "linux-image-amd64",
+	      	"i386" :  "linux-image-686" }
+}

--- a/providers/ec2/tasks/packages.py
+++ b/providers/ec2/tasks/packages.py
@@ -19,8 +19,8 @@ class DefaultPackages(Task):
 
 		# In squeeze, we need a special kernel flavor for xen
 		kernels = {}
-		with open('packages-kernels.json') as stream:
+		with open('providers/ec2/tasks/packages-kernels.json') as stream:
 			import json
-			kernel = json.loads(stream.read())
+			kernels = json.loads(stream.read())
 		kernel_package = kernels.get(info.manifest.system['release']).get(info.manifest.system['architecture'])
 		info.packages.add(kernel_package)

--- a/providers/ec2/tasks/packages.py
+++ b/providers/ec2/tasks/packages.py
@@ -18,9 +18,9 @@ class DefaultPackages(Task):
 		info.exclude_packages.add('isc-dhcp-common')
 
 		# In squeeze, we need a special kernel flavor for xen
-		kernels = {'squeeze': {'amd64': 'linux-image-xen-amd64',
-		                       'i386':  'linux-image-xen-686', },
-		           'wheezy':  {'amd64': 'linux-image-amd64',
-		                       'i386':  'linux-image-686', }, }
+		kernels = {}
+		with open('packages-kernels.json') as stream:
+			import json
+			kernel = json.loads(stream.read())
 		kernel_package = kernels.get(info.manifest.system['release']).get(info.manifest.system['architecture'])
 		info.packages.add(kernel_package)


### PR DESCRIPTION
I've added "unstable" option to manifest schema.
I've also moved release-specific configurations to JSON files as there will be more them - one for each release.
I've also disabled DISTRIBUTION-updates for unstable - it is only available for stable releases.
