### PR TITLE
Fix grub 40_custom template

### DIFF
--- a/providers/ec2/assets/grub.d/40_custom
+++ b/providers/ec2/assets/grub.d/40_custom
@@ -29,7 +29,7 @@ linux_entry ()
 {
 	os="$1"
 	version="$2"
-	args="$4"
+	args="$3"
 
 	title="$(gettext_quoted "%s, with Linux %s")"
 


### PR DESCRIPTION
`update-grub` command doesn't honor `GRUB_CMDLINE_LINUX` and `GRUB_CMDLINE_LINUX_DEFAULT` options.
