### PR TITLE
Add testing distribution and sections

### DIFF
--- a/base/manifest-schema.json
+++ b/base/manifest-schema.json
@@ -25,7 +25,8 @@
 		"system": {
 			"type": "object",
 			"properties": {
-				"release":      { "enum": ["wheezy", "unstable"] },
+				"release":      { "enum": ["wheezy", "testing", "unstable"] },
+				"sections":     { "type": "array" },				
 				"architecture": { "enum": ["i386", "amd64"] },
 				"bootloader":   { "enum": ["pvgrub", "grub", "extlinux"] },
 				"timezone":     { "type": "string" },

--- a/base/manifest-schema.json
+++ b/base/manifest-schema.json
@@ -26,7 +26,10 @@
 			"type": "object",
 			"properties": {
 				"release":      { "enum": ["wheezy", "testing", "unstable"] },
-				"sections":     { "type": "array" },				
+				"sections":     {
+					"type": "array",
+					"minItems": 1
+				},				
 				"architecture": { "enum": ["i386", "amd64"] },
 				"bootloader":   { "enum": ["pvgrub", "grub", "extlinux"] },
 				"timezone":     { "type": "string" },

--- a/common/tasks/apt.py
+++ b/common/tasks/apt.py
@@ -28,7 +28,7 @@ class AddDefaultSources(Task):
 			sections = ' '.join(info.manifest.system['sections'])
 		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} '+sections)
 		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} '+sections)
-		if info.manifest.system['release'] in {'testing', 'unstable'}:
+		if info.manifest.system['release'] not in {'testing', 'unstable'}:
 			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates '+sections)
 			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates '+sections)
 

--- a/common/tasks/apt.py
+++ b/common/tasks/apt.py
@@ -23,11 +23,14 @@ class AddDefaultSources(Task):
 
 	@classmethod
 	def run(cls, info):
-		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} main')
-		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} main')
-		if info.manifest.system['release'] != 'unstable':
-			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates main')
-			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates main')
+		sections = 'main'
+		if 'sections' in info.manifest.system:
+			sections = ' '.join(info.manifest.system['sections'])
+		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} '+sections)
+		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} '+sections)
+		if info.manifest.system['release'] in {'testing', 'unstable'}:
+			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates '+sections)
+			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates '+sections)
 
 
 class InstallTrustedKeys(Task):

--- a/common/tasks/network-configuration.json
+++ b/common/tasks/network-configuration.json
@@ -7,6 +7,9 @@
 	"wheezy": [
 		"auto eth0",
 		"iface eth0 inet dhcp" ],
+	"testing": [
+		"auto eth0",
+		"iface eth0 inet dhcp" ],
 	"unstable": [
 		"auto eth0",
 		"iface eth0 inet dhcp" ]

--- a/manifests/ec2-ebs-debian-testing-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-testing-amd64-pvm.manifest.json
@@ -1,0 +1,44 @@
+{
+	"provider":       "ec2",
+	"virtualization": "pvm",
+	"credentials":    {
+		// "access-key": null,
+		// "secret-key": null
+	},
+
+	"bootstrapper": {
+		"workspace": "/target"
+	},
+	"image": {
+		"name":        "debian-{system.release}-{system.architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {system.release} {system.architecture}"
+	},
+	"system": {
+		"release":      "testing",
+		"architecture": "amd64",
+		"bootloader":   "pvgrub",
+		"timezone":     "UTC",
+		"locale":       "en_US",
+		"charmap":      "UTF-8"
+	},
+	"packages": {
+		"mirror": "http://cloudfront.debian.net/debian"
+	},
+	"volume": {
+		"backing": "ebs",
+		"partitions": {
+			"type": "none",
+			"root": {
+				"size":       "8GiB",
+				"filesystem": "ext4"
+			}
+		}
+	},
+	"plugins": {
+		"cloud_init": {
+			"username": "admin",
+			//"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
+		}
+	}
+}

--- a/manifests/ec2-ebs-debian-unstable-contrib-amd64-pvm.manifest.json
+++ b/manifests/ec2-ebs-debian-unstable-contrib-amd64-pvm.manifest.json
@@ -1,0 +1,45 @@
+{
+	"provider":       "ec2",
+	"virtualization": "pvm",
+	"credentials":    {
+		// "access-key": null,
+		// "secret-key": null
+	},
+
+	"bootstrapper": {
+		"workspace": "/target"
+	},
+	"image": {
+		"name":        "debian-{system.release}-{system.architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs",
+		"description": "Debian {system.release} {system.architecture}"
+	},
+	"system": {
+		"release":      "unstable",
+		"sections":     ["main", "contrib", "non-free"],
+		"architecture": "amd64",
+		"bootloader":   "pvgrub",
+		"timezone":     "UTC",
+		"locale":       "en_US",
+		"charmap":      "UTF-8"
+	},
+	"packages": {
+		"mirror": "http://cloudfront.debian.net/debian"
+	},
+	"volume": {
+		"backing": "ebs",
+		"partitions": {
+			"type": "none",
+			"root": {
+				"size":       "8GiB",
+				"filesystem": "ext4"
+			}
+		}
+	},
+	"plugins": {
+		"cloud_init": {
+			"username": "admin",
+			//"metadata_sources": "Ec2",
+			"disable_modules": [ "landscape", "byobu", "ssh-import-id" ]
+		}
+	}
+}

--- a/providers/ec2/tasks/packages-kernels.json
+++ b/providers/ec2/tasks/packages-kernels.json
@@ -5,6 +5,9 @@
 	"wheezy": {
 		"amd64": "linux-image-amd64",
 	      	"i386" :  "linux-image-686" },
+	"testing": {
+		"amd64": "linux-image-amd64",
+	      	"i386" :  "linux-image-686" },
 	"unstable": {
 		"amd64": "linux-image-amd64",
 	      	"i386" :  "linux-image-686" }


### PR DESCRIPTION
This change adds ability to create images for testing, and to add contrib and non-free sections. The latter will be especially useful for GPGPU instances.
