### PR TITLE
GCE shell branch work, November 2013 through now

### DIFF
--- a/gce
+++ b/gce
@@ -9,6 +9,8 @@ image_name_suffix=v$(date +%Y%m%d)
 build_date=$(date +%Y-%m-%d)
 volume_size='10'
 apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
+backports_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://ftp.debian.org/debian'
+use_backports_kernel=false
 gce_kernel=projects/google/global/kernels/gce-v20130813
 
 # $description is set later if it has no value yet. This is
@@ -36,6 +38,8 @@ ${txtund}Bootstrapping${txtdef}
     --name SUFFIX                 Image name suffix (${txtbld}${name_suffix}${txtdef})
     --description DESC            Description of the image (${txtbld}${default_description}${txtdef})
     --apt-mirrors \"URL[ URL...]\"  APT mirror URLs, space-separated (${txtbld}${apt_mirrors}${txtdef})
+    --backports-mirrors \"URL[ URL...]\"  Backports APT mirror URLs, space-separated (${txtbld}${apt_mirrors}${txtdef})
+    --use-backports-kernel [true|false]  True if backports kernel should be used (${txtbld}${apt_mirrors}${txtdef})
 
 ${txtund}GCE${txtdef}
     --gcs-dest URL                Google Cloud Storage image destination URL prefix (${txtbld}${gcs_dest}${txtdef})
@@ -50,22 +54,24 @@ ${txtund}Other options${txtdef}
 # Run through the parameters and save them to variables.
 while [ $# -gt 0 ]; do
 	case $1 in
-		--arch)             arch=$2;                       shift 2 ;;
-		--codename)         codename=$2;                   shift 2 ;;
-		--filesystem)       filesystem=$2;                 shift 2 ;;
-		--volume-size)      volume_size=$2;                shift 2 ;;
-		--name)             name_suffix=$2;                shift 2 ;;
-		--description)      description=$2;                shift 2 ;;
-		--apt-mirrors)      apt_mirrors=$2;                shift 2 ;;
-		--gcs-dest)         gcs_dest=$2;                   shift 2 ;;
-		--gce-project)      gce_project=$2;                shift 2 ;;
-		--gce-kernel)       gce_kernel=$2;                 shift 2 ;;
-		--timezone)         timezone=$2;                   shift 2 ;;
-		--locale)           locale=$2;                     shift 2 ;;
-		--charmap)          charmap=$2;                    shift 2 ;;
-		--plugin)           plugins+=("$2");               shift 2 ;;
-		--debug)            set -x;                        shift   ;;
-		-h|--help)          printf -- "$help";             exit 0  ;;
+		--arch)                 arch=$2;                       shift 2 ;;
+		--codename)             codename=$2;                   shift 2 ;;
+		--filesystem)           filesystem=$2;                 shift 2 ;;
+		--volume-size)          volume_size=$2;                shift 2 ;;
+		--name)                 name_suffix=$2;                shift 2 ;;
+		--description)          description=$2;                shift 2 ;;
+		--apt-mirrors)          apt_mirrors=$2;                shift 2 ;;
+		--backports-mirrors)    backports_mirrors=$2;          shift 2 ;;
+		--use-backports-kernel) use_backports_kernel=$2;       shift 2 ;;
+		--gcs-dest)             gcs_dest=$2;                   shift 2 ;;
+		--gce-project)          gce_project=$2;                shift 2 ;;
+		--gce-kernel)           gce_kernel=$2;                 shift 2 ;;
+		--timezone)             timezone=$2;                   shift 2 ;;
+		--locale)               locale=$2;                     shift 2 ;;
+		--charmap)              charmap=$2;                    shift 2 ;;
+		--plugin)               plugins+=("$2");               shift 2 ;;
+		--debug)                set -x;                        shift   ;;
+		-h|--help)              printf -- "$help";             exit 0  ;;
 		*)             die "Unrecognized option: $1" \
     "Type '$0 --help' to see a list of possible options"; ;;
 	esac

--- a/tasks/gce/21-apt-backport-sources
+++ b/tasks/gce/21-apt-backport-sources
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Basic backports.list. Used to install kernel from backports
+
+if $use_backports_kernel; then
+echo 'using backports'
+for backports_mirror in $backports_mirrors; do
+cat >> $imagedir/etc/apt/sources.list.d/backports.list <<EOF
+deb     $backports_mirror wheezy-backports         main contrib non-free
+deb-src $backports_mirror wheezy-backports         main contrib non-free
+EOF
+done
+fi

--- a/tasks/gce/21-prefer-backports-kernel
+++ b/tasks/gce/21-prefer-backports-kernel
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Prefer backports kernel
+
+if $use_backports_kernel; then
+echo 'using backports'
+cat >> $imagedir/etc/apt/preferences.d/backports-kernel.pref <<EOF
+Package: linux-image-* initramfs-tools
+Pin: release n=wheezy-backports
+Pin-Priority: 500
+EOF
+fi

--- a/tasks/gce/25-install-gce-debs
+++ b/tasks/gce/25-install-gce-debs
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Add GCE startup scripts and packages to the image.
 
-DEBS="google-compute-daemon google-startup-scripts image-bundle gcutil"
+DEBS="google-compute-daemon google-startup-scripts python-gcimagebundle gcutil"
 for deb in $DEBS; do
   chroot $imagedir apt-get install --force-yes -y ${deb}
 done

--- a/tasks/gce/37-fix-ntp
+++ b/tasks/gce/37-fix-ntp
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Change NTP to use Google servers instead of Debian pool
+
+CONFIGURATION_FILE=etc/ntp.conf
+CONFIGURATION_TEMP_FILE=etc/ntp.conf.tmp
+
+mv $imagedir/$CONFIGURATION_FILE $imagedir/$CONFIGURATION_TEMP_FILE
+grep -v '^server\s\+' <$imagedir/$CONFIGURATION_TEMP_FILE >$imagedir/$CONFIGURATION_FILE
+echo "server metadata.google.internal" >>$imagedir/$CONFIGURATION_FILE
+rm $imagedir/$CONFIGURATION_TEMP_FILE
+

--- a/tasks/gce/37-fix-ntp
+++ b/tasks/gce/37-fix-ntp
@@ -1,12 +1,10 @@
 #!/bin/bash
 #
-# Change NTP to use Google servers instead of Debian pool
+# Change NTP to use server located on the host machine instead of Debian pool
 
-CONFIGURATION_FILE=etc/ntp.conf
-CONFIGURATION_TEMP_FILE=etc/ntp.conf.tmp
+configuration_file=etc/ntp.conf
 
-mv $imagedir/$CONFIGURATION_FILE $imagedir/$CONFIGURATION_TEMP_FILE
-grep -v '^server\s\+' <$imagedir/$CONFIGURATION_TEMP_FILE >$imagedir/$CONFIGURATION_FILE
-echo "server metadata.google.internal" >>$imagedir/$CONFIGURATION_FILE
-rm $imagedir/$CONFIGURATION_TEMP_FILE
+sed --in-place=.tmp 's/^server\s\+/# &/' $imagedir/$configuration_file
+echo "# Use server located on the host machine to avoid network traffic" >>$imagedir/$configuration_file
+echo "server metadata.google.internal iburst" >>$imagedir/$configuration_file
 

--- a/tasks/gce/37-fix-ntp
+++ b/tasks/gce/37-fix-ntp
@@ -4,7 +4,7 @@
 
 configuration_file=etc/ntp.conf
 
-sed --in-place=.tmp 's/^server\s\+/# &/' $imagedir/$configuration_file
+sed --in-place=.tmp '/^server\s\+/d' $imagedir/$configuration_file
 echo "# Use server located on the host machine to avoid network traffic" >>$imagedir/$configuration_file
 echo "server metadata.google.internal iburst" >>$imagedir/$configuration_file
 

--- a/tasks/gce/37-fix-ntp
+++ b/tasks/gce/37-fix-ntp
@@ -4,7 +4,7 @@
 
 configuration_file=etc/ntp.conf
 
-sed --in-place=.tmp '/^server\s\+/d' $imagedir/$configuration_file
+sed --in-place '/^server\s\+/d' $imagedir/$configuration_file
 echo "# Use server located on the host machine to avoid network traffic" >>$imagedir/$configuration_file
 echo "server metadata.google.internal iburst" >>$imagedir/$configuration_file
 

--- a/tasks/gce/39-set-hostname
+++ b/tasks/gce/39-set-hostname
@@ -2,3 +2,6 @@
 
 # Set the hostname from DHCP.
 chroot $imagedir ln -s /usr/share/google/set-hostname /etc/dhcp/dhclient-exit-hooks.d/set-hostname
+
+# For now set the hostname to localhost, this will be changed on first boot of the VM.
+echo "localhost" >> $imagedir/etc/hostname

--- a/tasks/gce/39-set-hostname
+++ b/tasks/gce/39-set-hostname
@@ -3,5 +3,5 @@
 # Set the hostname from DHCP.
 chroot $imagedir ln -s /usr/share/google/set-hostname /etc/dhcp/dhclient-exit-hooks.d/set-hostname
 
-# For now set the hostname to localhost, this will be changed on first boot of the VM.
+# For now provide a reasonable default for the hostname. It will be updated when the VM boots.
 echo "localhost" >> $imagedir/etc/hostname


### PR DESCRIPTION
Roughly speaking:
- Oldest four commits, through commit 25d20d1b6f5f424c2c59b346019874dce5c639e7, line up with the debian-cloud images dated 20131120 and (backports kernel) 20131127, which are current and were published in connection with Google Compute Engine general availability. This includes:
  - Rename old image_bundle tool to gcimagebundle
  - Add support for --use-backports-kernel true, to pull in the backports kernel and set up apt_preferences to prefer it. (Courtesy of my colleague @HimanshuVasishth)
- @rybaktomasz added support for using the host environment's NTP server. Not only is this a best practice in virtual environments, it allows time sync for GCE instances configured without external connectivity.
- Work around the hostname.sh issue for GCE instances. (Courtesy of my colleague @jeremyje)
